### PR TITLE
fix docker and dependency

### DIFF
--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -1,37 +1,33 @@
-# gcc10 doesn't like me, and it seems the official appimage is build using gcc 5.4.0-6ubuntu1~16.04.12
-FROM conanio/gcc5
-RUN conan remote add eliza "https://rkevin.jfrog.io/artifactory/api/conan/eliza" && \
-conan remote add bincrafters "https://bincrafters.jfrog.io/artifactory/api/conan/public-conan" && \
-conan remote add astrabit "https://rkevin.jfrog.io/artifactory/api/conan/astrabit" && \
-conan config set general.revisions_enabled=1
+# To run this image put the OSFM-Core-Public repo in the same folder as this dockerfile, this will become the work directory
 
-RUN sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y \
-xorg-dev libx11-xcb-dev libxcb-render0-dev libxcb-render-util0-dev libgtk2.0-dev libxfconf-0-dev vim libwmf0.2-7-gtk librsvg2-common rsync patchelf dos2unix && \
-sudo rm -rf /var/lib/apt/lists/*
-RUN sudo python -m pip install mako pyqt5 pyinstaller
+FROM ubuntu:rolling
 
-# install all dependencies for the conanfile in commit
-COPY --chown=conan:root conanfile.py /tmp/install_deps/conanfile.py
-RUN conan install --build=missing /tmp/install_deps && sudo rm -r /tmp/install_deps
+RUN useradd -ms /bin/bash builder
+ADD OSFM-Core-Public/setup.sh /home/builder/setup.sh
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+	 sudo \
+         wget \
+         g++ \
+         git \
+         automake \
+         autoconf \
+         autotools-dev \
+         libtool \
+         ninja-build \
+         bash \
+         python3-pip \
+         dos2unix && \
+    /home/builder/setup.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage /tmp
-# can't find a stable release for linuxdeploy, oh well
-ADD https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage /tmp
-# avoid having to run appimages by itself
-# we don't want to force CAP_SYS_ADMIN into the container if possible, but running appimages require FUSE
-# instead, we extract it and pray it works (it actually does!)
-RUN cd /tmp && sudo chmod 755 appimagetool-x86_64.AppImage linuxdeploy-x86_64.AppImage && \
-./appimagetool-x86_64.AppImage --appimage-extract && sudo mv squashfs-root /usr/local/bin/appimagetool && \
-./linuxdeploy-x86_64.AppImage --appimage-extract && sudo mv squashfs-root /usr/local/bin/linuxdeploy && \
-sudo ln -s /usr/local/bin/appimagetool/AppRun /usr/local/bin/appimagetool-x86_64.AppImage && \
-sudo ln -s /usr/local/bin/linuxdeploy/AppRun /usr/local/bin/linuxdeploy-x86_64.AppImage
-
-ENTRYPOINT ["bash", "-c", "dos2unix /work/src/build-entrypoint-linux.sh && chmod +x /work/src/build-entrypoint-linux.sh && /work/src/build-entrypoint-linux.sh"]
+USER builder
+WORKDIR /home/builder
+ENTRYPOINT ["bash"] 
 
 # build this docker image as follows:
 # docker build -t oneshot-build-linux .
 
 # run this docker image as follows:
-# docker run -i -v /path/to/modshot-core:/work/src -v /path/to/gamefiles:/work/data -v /path/to/distrubution/folder:/work/dist oneshot-build-linux
-# example that worked for me:
-# docker run -i -v ~/o/Modshot-Core:/work/src -v ~/o/OneShotBkup:/work/data -v ~/o/conanbuildtest:/work/dist oneshot-build-linux
+# docker run -i -v /path/to/modshot-core:/home/builder/work -v /path/to/gamefiles:/home/builder/data -v /path/to/distrubution/folder:/home/builder/dist oneshot-build-linux

--- a/setup.sh
+++ b/setup.sh
@@ -20,8 +20,8 @@ else
         sudo apt install -y gcc make cmake vim ruby bison doxygen meson \
         libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libopenal-dev \
         libphysfs-dev libpixman-1-dev libwebp-dev libbz2-dev libvorbis-dev \
-        libogg-dev libsodium-dev libboost-dev libpng-dev libjpeg-dev \
-        libtiff-dev libsigc++-2.0-dev libgtk-3-dev libxfconf-0-dev \
+        libogg-dev libsodium-dev libboost-dev libboost-program-options-dev libpng-dev \
+        libjpeg-dev libtiff-dev libsigc++-2.0-dev libgtk-3-dev libxfconf-0-dev \
         libfreetype-dev libharfbuzz-dev
     fi
 


### PR DESCRIPTION
When trying to compile I ran into the issue that the Dockerfile was outdated and that the setup.sh was missing a depend, I know you do not have linux builds yet, but this should help compile when the linux builds are back. 

I tried to match the dockerfile with the github runner