### PR TITLE
fix otherview causing segfault

### DIFF
--- a/src/thread/source/eventthread.cpp
+++ b/src/thread/source/eventthread.cpp
@@ -713,8 +713,6 @@ void EventThread::cleanup()
 	while (SDL_PollEvent(&event))
 		if ((event.type - usrIdStart) == REQUEST_MESSAGEBOX)
 			free(event.user.data1);
-
-	shState->otherView().close(); // Bad place to do this but I don't care
 }
 
 void EventThread::resetInputStates()


### PR DESCRIPTION
Ran into a segfault closing the application, i don't think you need to explicitly close the sockets as this happens in the destructor. See: 
![image](https://user-images.githubusercontent.com/9693338/201703118-e17e58b6-c5da-4442-8115-126f3503a419.png)

Having removed this call the sockets still get closed without the segfault.
Crashlog:
[crash.txt](https://github.com/Speak2Erase/OSFM-Core-Public/files/10004649/crash.txt)
